### PR TITLE
mail chimp configuration

### DIFF
--- a/app/controllers/subscribe_emails_controller.rb
+++ b/app/controllers/subscribe_emails_controller.rb
@@ -1,0 +1,7 @@
+class SubscribeEmailsController < ActionController::Base
+  def subscribe
+    email = params[:email]
+
+    SubscribeUserToMailingListJob.perform email
+  end
+end

--- a/app/controllers/subscribe_emails_controller.rb
+++ b/app/controllers/subscribe_emails_controller.rb
@@ -2,6 +2,6 @@ class SubscribeEmailsController < ActionController::Base
   def subscribe
     email = params[:email]
 
-    SubscribeUserToMailingListJob.perform email
+    SubscribeUserToMailingListJob.perform_later email
   end
 end

--- a/app/jobs/subscribe_user_to_mailing_list_job.rb
+++ b/app/jobs/subscribe_user_to_mailing_list_job.rb
@@ -2,11 +2,9 @@ class SubscribeUserToMailingListJob < ApplicationJob
   queue_as :default 
 
   def perform(email)
-    gb = Gibbon::API.new
-    gb.lists.subscribe({
-      id: ENV["MC_LIST"],
-      email: { email: email },
-      double_optin: false
+    gibbon = Gibbon::Request.new
+    gibbon.lists(ENV["MC_LIST"]).members.create({
+      body: { email_address: email, status: "subscribed" }
     })
   end
 end

--- a/app/jobs/subscribe_user_to_mailing_list_job.rb
+++ b/app/jobs/subscribe_user_to_mailing_list_job.rb
@@ -1,3 +1,12 @@
 class SubscribeUserToMailingListJob < ApplicationJob
-  
+  queue_as :default 
+
+  def perform(email)
+    gb = Gibbon::API.new
+    gb.lists.subscribe({
+      id: ENV["MC_LIST"],
+      email: { email: email },
+      double_optin: false
+    })
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -97,33 +97,35 @@
 <div class="line"></div>
 <div class="line"></div></div></label>
     <input type="checkbox" id="show-menu" role="button">
-        <ul style="margin-left: 0px; margin-top: -94px;" id="menu">
-        <li><a <%= link_to "Coven", home_index_url(:anchor => "meet_the_coven") %></a></li>
-        <li>
-            <a <%= link_to "Get Educated", contact_index_url %></a>
-            <ul class="hidden">
-             <li><a <%= link_to "FAQ", faq_index_url %></a></li>
-                <li><a <%= link_to "Hemp Dictionary", hemp_dictionary_index_url %></a></li>
-                <li><a <%= link_to "Recipes", recipes_index_url %></a></li>
-                <li><a <%= link_to "Resources", recipes_index_url %></a></li>
-            </ul>
-        </li>
-       <li>
-            <a <%= link_to "Shop", shop_index_url %></a>
-            <ul class="hidden2">
-               <li><a <%= link_to "Where to Buy", locations_index_url %></a></li>
-            </ul>
-        </li>
-    
-
+      <ul style="margin-left: 0px; margin-top: -94px;" id="menu">
+      <li><a <%= link_to "Coven", home_index_url(:anchor => "meet_the_coven") %></a></li>
+      <li>
+        <a <%= link_to "Get Educated", contact_index_url %></a>
+        <ul class="hidden">
+          <li><a <%= link_to "FAQ", faq_index_url %></a></li>
+          <li><a <%= link_to "Hemp Dictionary", hemp_dictionary_index_url %></a></li>
+          <li><a <%= link_to "Recipes", recipes_index_url %></a></li>
+          <li><a <%= link_to "Resources", recipes_index_url %></a></li>
+        </ul>
+      </li>
+      <li>
+        <a <%= link_to "Shop", shop_index_url %></a>
+        <ul class="hidden2">
+          <li><a <%= link_to "Where to Buy", locations_index_url %></a></li>
+        </ul>
+      </li>
     </div>
-
-</div>
 </div>
 
+</div>
+  <%= yield %>
+</body>
 
+<footer>
+  <%= form_tag '/subscribe_email', method: :post do %>
+    <%= email_field_tag 'email' %>
+    <%= submit_tag "Subscribe" %>
+  <% end %>
+</footer>
 
-
-    <%= yield %>
-  </body>
 </html>

--- a/config/initializers/mailchimp.rb
+++ b/config/initializers/mailchimp.rb
@@ -1,3 +1,3 @@
-Gibbon::API.api_key = ENV["MC_NAME"]
-Gibbon::API.timeout = 15
-Gibbon::API.throw_exceptions = true
+Gibbon::Request.api_key = ENV["MC_NAME"]
+Gibbon::Request.timeout = 15
+Gibbon::Request.debug = false

--- a/config/initializers/mailchimp.rb
+++ b/config/initializers/mailchimp.rb
@@ -1,0 +1,3 @@
+Gibbon::API.api_key = ENV["MC_NAME"]
+Gibbon::API.timeout = 15
+Gibbon::API.throw_exceptions = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  post "/subscribe_email" => "subscribe_emails#subscribe"
+
   get 'locations/index'
 
   get 'promotions/index'
@@ -21,4 +23,4 @@ Rails.application.routes.draw do
   get "/" => "home#index"
 end
 
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+# For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
uses `ActiveJob` to subscribe users onto mailchimp upon clicking submit after inputting his/her email into the input tag located at the `footer`.

Requires Mailchimp's `API_KEY` and `LIST_ID` to work.